### PR TITLE
Add Fare

### DIFF
--- a/prisma/schema/fare.prisma
+++ b/prisma/schema/fare.prisma
@@ -1,0 +1,12 @@
+model FareSettings {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  baseFare      Float    @default(15.0)  // Base fare in PHP
+  ratePerKm     Float    @default(8.0)   // Rate per kilometer in PHP
+  minimumFare   Float?                   // Optional minimum fare
+  maximumFare   Float?                   // Optional maximum fare
+  timeBasedRate Float?                   // Optional time-based rate (PHP per minute)
+  isActive      Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  isDeleted     Boolean  @default(false)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import rideRoutes from "./routes/ride.route";
 import paymentRoutes from "./routes/payment.route";
 import ratingRoutes from "./routes/rating.route";
 import locationRoutes from "./routes/location.route";
+import fareRoutes from "./routes/fare.route";
 
 // Import middleware
 import { errorHandler } from "./middleware/error.handler";
@@ -68,6 +69,7 @@ app.use("/api/ride", rideRoutes);
 app.use("/api/payment", paymentRoutes);
 app.use("/api/rating", ratingRoutes);
 app.use("/api/location", locationRoutes);
+app.use("/api/fare", fareRoutes);
 
 // Error handling middleware
 app.use(notFound);

--- a/src/routes/fare.route.ts
+++ b/src/routes/fare.route.ts
@@ -1,0 +1,330 @@
+import express, { Request, Response } from "express";
+import fareService from "../services/fare.service";
+import { authenticate } from "../middleware/auth";
+import { requireAdmin } from "../middleware/rbac";
+import { logInfo, logError } from "../middleware/logger";
+
+const router = express.Router();
+
+// Public route to get current fare settings
+router.get("/current", getCurrentFareSettings);
+
+// Public route to calculate fare
+router.get("/calculate", calculateFare);
+
+// Admin routes
+router.get("/", authenticate, requireAdmin, getAllFareSettings);
+router.post("/", authenticate, requireAdmin, createFareSettings);
+router.patch("/:id", authenticate, requireAdmin, updateFareSettings);
+router.delete("/:id", authenticate, requireAdmin, deleteFareSettings);
+
+// @route   GET /api/fare/current
+// @desc    Get current active fare settings
+// @access  Public
+async function getCurrentFareSettings(req: Request, res: Response) {
+  try {
+    const result = await fareService.getCurrentFareSettings();
+
+    if (!result.success) {
+      logError("Failed to get current fare settings", result.message, req);
+      return res.status(500).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo("Successfully retrieved current fare settings", req);
+    res.json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } catch (error) {
+    logError("Get current fare settings error", error, req);
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+// @route   GET /api/fare/calculate?distance=5.2&estimatedTime=15&surgeMultiplier=1.5
+// @desc    Calculate fare based on distance with enhanced options
+// @access  Public
+async function calculateFare(req: Request, res: Response) {
+  try {
+    const { distance, estimatedTime, surgeMultiplier } = req.query;
+
+    if (!distance) {
+      logError("Missing distance parameter", "Distance is required", req);
+      return res.status(400).json({
+        success: false,
+        message: "Distance parameter is required",
+      });
+    }
+
+    const distanceNum = Number(distance);
+    if (isNaN(distanceNum) || distanceNum < 0) {
+      logError("Invalid distance parameter", `Distance: ${distance}`, req);
+      return res.status(400).json({
+        success: false,
+        message: "Distance must be a valid positive number",
+      });
+    }
+
+    // Parse optional parameters
+    const options: { estimatedTime?: number; surgeMultiplier?: number } = {};
+
+    if (estimatedTime && !isNaN(Number(estimatedTime)) && Number(estimatedTime) > 0) {
+      options.estimatedTime = Number(estimatedTime);
+    }
+
+    if (surgeMultiplier && !isNaN(Number(surgeMultiplier)) && Number(surgeMultiplier) >= 1) {
+      options.surgeMultiplier = Number(surgeMultiplier);
+    }
+
+    const result = await fareService.getFareCalculation(distanceNum, options);
+
+    if (!result.success) {
+      logError("Failed to calculate fare", result.message, req);
+      return res.status(500).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo(`Successfully calculated fare for distance: ${distanceNum}km`, req);
+    res.json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } catch (error) {
+    logError("Calculate fare error", error, req);
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+// @route   GET /api/fare
+// @desc    Get all fare settings (Admin only)
+// @access  Private (Admin)
+async function getAllFareSettings(req: Request, res: Response) {
+  try {
+    const result = await fareService.getAllFareSettings(req.user?.role);
+
+    if (!result.success) {
+      logError("Failed to get fare settings", result.message, req);
+      return res.status(500).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo(`Successfully retrieved ${result.data?.length || 0} fare settings`, req);
+    res.json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } catch (error) {
+    logError("Get fare settings error", error, req);
+    if (error instanceof Error && error.message === "Insufficient permissions") {
+      return res.status(403).json({
+        success: false,
+        message: "Insufficient permissions",
+      });
+    }
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+// @route   POST /api/fare
+// @desc    Create new fare settings (Admin only)
+// @access  Private (Admin)
+async function createFareSettings(req: Request, res: Response) {
+  try {
+    const { baseFare, ratePerKm } = req.body;
+
+    if (!baseFare || !ratePerKm) {
+      logError("Missing required fields", "baseFare and ratePerKm are required", req);
+      return res.status(400).json({
+        success: false,
+        message: "baseFare and ratePerKm are required",
+      });
+    }
+
+    if (isNaN(Number(baseFare)) || Number(baseFare) <= 0) {
+      logError("Invalid baseFare", `baseFare: ${baseFare}`, req);
+      return res.status(400).json({
+        success: false,
+        message: "baseFare must be a positive number",
+      });
+    }
+
+    if (isNaN(Number(ratePerKm)) || Number(ratePerKm) <= 0) {
+      logError("Invalid ratePerKm", `ratePerKm: ${ratePerKm}`, req);
+      return res.status(400).json({
+        success: false,
+        message: "ratePerKm must be a positive number",
+      });
+    }
+
+    const result = await fareService.createFareSettings(
+      {
+        baseFare: Number(baseFare),
+        ratePerKm: Number(ratePerKm),
+      },
+      req.user?.role
+    );
+
+    if (!result.success) {
+      logError("Failed to create fare settings", result.message, req);
+      return res.status(400).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo("Successfully created fare settings", req);
+    res.status(201).json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } catch (error) {
+    logError("Create fare settings error", error, req);
+    if (error instanceof Error && error.message === "Insufficient permissions") {
+      return res.status(403).json({
+        success: false,
+        message: "Insufficient permissions",
+      });
+    }
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+// @route   PATCH /api/fare/:id
+// @desc    Update fare settings (Admin only)
+// @access  Private (Admin)
+async function updateFareSettings(req: Request, res: Response) {
+  try {
+    const { id } = req.params;
+    const { baseFare, ratePerKm, isActive } = req.body;
+
+    if (!id) {
+      logError("Missing ID parameter", "ID is required", req);
+      return res.status(400).json({
+        success: false,
+        message: "ID is required",
+      });
+    }
+
+    // Validate baseFare if provided
+    if (baseFare !== undefined && (isNaN(Number(baseFare)) || Number(baseFare) <= 0)) {
+      logError("Invalid baseFare", `baseFare: ${baseFare}`, req);
+      return res.status(400).json({
+        success: false,
+        message: "baseFare must be a positive number",
+      });
+    }
+
+    // Validate ratePerKm if provided
+    if (ratePerKm !== undefined && (isNaN(Number(ratePerKm)) || Number(ratePerKm) <= 0)) {
+      logError("Invalid ratePerKm", `ratePerKm: ${ratePerKm}`, req);
+      return res.status(400).json({
+        success: false,
+        message: "ratePerKm must be a positive number",
+      });
+    }
+
+    const updateData: any = {};
+    if (baseFare !== undefined) updateData.baseFare = Number(baseFare);
+    if (ratePerKm !== undefined) updateData.ratePerKm = Number(ratePerKm);
+    if (isActive !== undefined) updateData.isActive = Boolean(isActive);
+
+    const result = await fareService.updateFareSettings(id, updateData, req.user?.role);
+
+    if (!result.success) {
+      logError(`Failed to update fare settings: ${id}`, result.message, req);
+      return res.status(404).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo(`Successfully updated fare settings: ${id}`, req);
+    res.json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } catch (error) {
+    logError("Update fare settings error", error, req);
+    if (error instanceof Error && error.message === "Insufficient permissions") {
+      return res.status(403).json({
+        success: false,
+        message: "Insufficient permissions",
+      });
+    }
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+// @route   DELETE /api/fare/:id
+// @desc    Delete fare settings (Admin only)
+// @access  Private (Admin)
+async function deleteFareSettings(req: Request, res: Response) {
+  try {
+    const { id } = req.params;
+
+    if (!id) {
+      logError("Missing ID parameter", "ID is required", req);
+      return res.status(400).json({
+        success: false,
+        message: "ID is required",
+      });
+    }
+
+    const result = await fareService.deleteFareSettings(id, req.user?.role);
+
+    if (!result.success) {
+      logError(`Failed to delete fare settings: ${id}`, result.message, req);
+      return res.status(404).json({
+        success: false,
+        message: result.message,
+      });
+    }
+
+    logInfo(`Successfully deleted fare settings: ${id}`, req);
+    res.json({
+      success: true,
+      message: result.message,
+    });
+  } catch (error) {
+    logError("Delete fare settings error", error, req);
+    if (error instanceof Error && error.message === "Insufficient permissions") {
+      return res.status(403).json({
+        success: false,
+        message: "Insufficient permissions",
+      });
+    }
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+}
+
+export default router;

--- a/src/services/fare.service.ts
+++ b/src/services/fare.service.ts
@@ -1,0 +1,396 @@
+import { Role } from "../types";
+import { requireAdminPermission } from "../middleware/rbac";
+import { getPrismaClient } from "../lib/db.connection";
+
+const prisma = getPrismaClient();
+
+export interface FareSettings {
+  id: string;
+  baseFare: number;
+  ratePerKm: number;
+  minimumFare?: number;
+  maximumFare?: number;
+  timeBasedRate?: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateFareSettingsData {
+  baseFare: number;
+  ratePerKm: number;
+  minimumFare?: number;
+  maximumFare?: number;
+  timeBasedRate?: number;
+}
+
+export interface UpdateFareSettingsData {
+  baseFare?: number;
+  ratePerKm?: number;
+  minimumFare?: number;
+  maximumFare?: number;
+  timeBasedRate?: number;
+  isActive?: boolean;
+}
+
+const fareService = {
+  getCurrentFareSettings,
+  getAllFareSettings,
+  createFareSettings,
+  updateFareSettings,
+  deleteFareSettings,
+  getFareCalculation,
+  calculateFare,
+};
+
+export default fareService;
+
+// Get current active fare settings
+async function getCurrentFareSettings() {
+  try {
+    const fareSettings = await prisma.fareSettings.findFirst({
+      where: {
+        isActive: true,
+        isDeleted: false,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    // If no fare settings exist, create default ones
+    if (!fareSettings) {
+      const defaultSettings = await prisma.fareSettings.create({
+        data: {
+          baseFare: 15.0,
+          ratePerKm: 8.0,
+          isActive: true,
+        },
+      });
+
+      return {
+        success: true,
+        message: "Default fare settings created",
+        data: defaultSettings,
+      };
+    }
+
+    return {
+      success: true,
+      message: "Current fare settings retrieved successfully",
+      data: fareSettings,
+    };
+  } catch (error) {
+    console.error("Get current fare settings error:", error);
+    return {
+      success: false,
+      message: "Failed to retrieve fare settings",
+      data: null,
+    };
+  }
+}
+
+// Get all fare settings (admin only)
+async function getAllFareSettings(userRole?: Role) {
+  try {
+    requireAdminPermission(userRole);
+
+    const fareSettings = await prisma.fareSettings.findMany({
+      where: {
+        isDeleted: false,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    return {
+      success: true,
+      message: "Fare settings retrieved successfully",
+      data: fareSettings,
+    };
+  } catch (error) {
+    console.error("Get all fare settings error:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Failed to retrieve fare settings",
+      data: null,
+    };
+  }
+}
+
+// Create new fare settings (admin only)
+async function createFareSettings(data: CreateFareSettingsData, userRole?: Role) {
+  try {
+    requireAdminPermission(userRole);
+
+    // Validate input
+    if (!data.baseFare || data.baseFare <= 0) {
+      return {
+        success: false,
+        message: "Base fare must be a positive number",
+        data: null,
+      };
+    }
+
+    if (!data.ratePerKm || data.ratePerKm <= 0) {
+      return {
+        success: false,
+        message: "Rate per km must be a positive number",
+        data: null,
+      };
+    }
+
+    // Deactivate all existing fare settings
+    await prisma.fareSettings.updateMany({
+      where: {
+        isActive: true,
+        isDeleted: false,
+      },
+      data: {
+        isActive: false,
+      },
+    });
+
+    // Create new fare settings
+    const newFareSettings = await prisma.fareSettings.create({
+      data: {
+        baseFare: data.baseFare,
+        ratePerKm: data.ratePerKm,
+        isActive: true,
+      },
+    });
+
+    return {
+      success: true,
+      message: "Fare settings created successfully",
+      data: newFareSettings,
+    };
+  } catch (error) {
+    console.error("Create fare settings error:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Failed to create fare settings",
+      data: null,
+    };
+  }
+}
+
+// Update fare settings (admin only)
+async function updateFareSettings(id: string, data: UpdateFareSettingsData, userRole?: Role) {
+  try {
+    requireAdminPermission(userRole);
+
+    // Check if fare settings exist
+    const existingSettings = await prisma.fareSettings.findFirst({
+      where: {
+        id,
+        isDeleted: false,
+      },
+    });
+
+    if (!existingSettings) {
+      return {
+        success: false,
+        message: "Fare settings not found",
+        data: null,
+      };
+    }
+
+    // Validate input
+    if (data.baseFare !== undefined && data.baseFare <= 0) {
+      return {
+        success: false,
+        message: "Base fare must be a positive number",
+        data: null,
+      };
+    }
+
+    if (data.ratePerKm !== undefined && data.ratePerKm <= 0) {
+      return {
+        success: false,
+        message: "Rate per km must be a positive number",
+        data: null,
+      };
+    }
+
+    // If setting as active, deactivate all other settings
+    if (data.isActive === true) {
+      await prisma.fareSettings.updateMany({
+        where: {
+          id: { not: id },
+          isActive: true,
+          isDeleted: false,
+        },
+        data: {
+          isActive: false,
+        },
+      });
+    }
+
+    // Update fare settings
+    const updatedSettings = await prisma.fareSettings.update({
+      where: { id },
+      data: {
+        ...data,
+        updatedAt: new Date(),
+      },
+    });
+
+    return {
+      success: true,
+      message: "Fare settings updated successfully",
+      data: updatedSettings,
+    };
+  } catch (error) {
+    console.error("Update fare settings error:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Failed to update fare settings",
+      data: null,
+    };
+  }
+}
+
+// Delete fare settings (admin only)
+async function deleteFareSettings(id: string, userRole?: Role) {
+  try {
+    requireAdminPermission(userRole);
+
+    // Check if fare settings exist
+    const existingSettings = await prisma.fareSettings.findFirst({
+      where: {
+        id,
+        isDeleted: false,
+      },
+    });
+
+    if (!existingSettings) {
+      return {
+        success: false,
+        message: "Fare settings not found",
+      };
+    }
+
+    // Don't allow deleting the active fare settings
+    if (existingSettings.isActive) {
+      return {
+        success: false,
+        message: "Cannot delete active fare settings",
+      };
+    }
+
+    // Soft delete
+    await prisma.fareSettings.update({
+      where: { id },
+      data: {
+        isDeleted: true,
+        updatedAt: new Date(),
+      },
+    });
+
+    return {
+      success: true,
+      message: "Fare settings deleted successfully",
+    };
+  } catch (error) {
+    console.error("Delete fare settings error:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Failed to delete fare settings",
+    };
+  }
+}
+
+// Calculate fare based on distance with enhanced options
+export function calculateFare(
+  distance: number,
+  baseFare: number,
+  ratePerKm: number,
+  options?: {
+    minimumFare?: number;
+    maximumFare?: number;
+    timeBasedRate?: number;
+    estimatedTime?: number;
+    surgeMultiplier?: number;
+  }
+): number {
+  let fare = baseFare + distance * ratePerKm;
+
+  // Add time-based fare if applicable
+  if (options?.timeBasedRate && options?.estimatedTime) {
+    fare += (options.estimatedTime / 60) * options.timeBasedRate;
+  }
+
+  // Apply surge pricing if applicable
+  if (options?.surgeMultiplier && options.surgeMultiplier > 1) {
+    fare *= options.surgeMultiplier;
+  }
+
+  // Apply minimum fare limit
+  if (options?.minimumFare) {
+    fare = Math.max(fare, options.minimumFare);
+  }
+
+  // Apply maximum fare limit
+  if (options?.maximumFare) {
+    fare = Math.min(fare, options.maximumFare);
+  }
+
+  return Math.round(fare * 100) / 100; // Round to 2 decimal places
+}
+
+// Get fare calculation with enhanced options
+async function getFareCalculation(
+  distance: number,
+  options?: {
+    estimatedTime?: number;
+    surgeMultiplier?: number;
+  }
+) {
+  try {
+    const fareSettingsResult = await getCurrentFareSettings();
+
+    if (!fareSettingsResult.success || !fareSettingsResult.data) {
+      return {
+        success: false,
+        message: "Failed to get fare settings",
+        data: null,
+      };
+    }
+
+    const fareSettings = fareSettingsResult.data;
+    const { baseFare, ratePerKm, minimumFare, maximumFare, timeBasedRate } = fareSettings;
+
+    const calculatedFare = calculateFare(distance, baseFare, ratePerKm, {
+      minimumFare: minimumFare || undefined,
+      maximumFare: maximumFare || undefined,
+      timeBasedRate: timeBasedRate || undefined,
+      estimatedTime: options?.estimatedTime,
+      surgeMultiplier: options?.surgeMultiplier,
+    });
+
+    return {
+      success: true,
+      message: "Fare calculated successfully",
+      data: {
+        distance,
+        baseFare,
+        ratePerKm,
+        minimumFare,
+        maximumFare,
+        timeBasedRate,
+        estimatedTime: options?.estimatedTime,
+        surgeMultiplier: options?.surgeMultiplier,
+        calculatedFare,
+      },
+    };
+  } catch (error) {
+    console.error("Calculate fare error:", error);
+    return {
+      success: false,
+      message: "Failed to calculate fare",
+      data: null,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete fare settings management feature for the application, including database schema changes, backend service logic, new API endpoints, and integration into the main Express app. The changes allow both public and admin users to retrieve, calculate, create, update, and delete fare settings, with robust validation and permission checks.

**Fare Settings Data Model and Service Layer**

* Added a new Prisma model `FareSettings` to support fare configuration, including fields for base fare, rate per kilometer, time-based rates, minimum/maximum fares, and status flags (`isActive`, `isDeleted`).
* Implemented `fare.service.ts` with functions to get current fare settings, retrieve all settings (admin only), create, update, soft-delete fare settings, and calculate fares with support for surge pricing and time-based rates. Includes admin permission checks and input validation.

**API Endpoints and Routing**

* Created `fare.route.ts` with public endpoints to get current fare settings and calculate fares, and admin endpoints to list, create, update, and delete fare settings. Includes middleware for authentication, admin role enforcement, and structured logging.
* Registered the new fare routes in the main Express app, making them available under `/api/fare`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R17) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R72)